### PR TITLE
Complete open order ml

### DIFF
--- a/app/controllers/customer_controller.rb
+++ b/app/controllers/customer_controller.rb
@@ -18,7 +18,7 @@ class CustomerController
 	def initialize(customer_hash = Hash.new)
 		@CustomerModel = CustomerModel.new
 		d = DateTime.now
-		date = "#{d.month}/#{d.day}#{d.year}"
+		date = "#{d.month}/#{d.day}/#{d.year}"
 		@customer_hash = customer_hash
 		@customer_hash[:created_at] = date
 		@customer_hash[:updated_at] = date

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -1,6 +1,7 @@
 require_relative './customer_controller.rb'
 require_relative './payment_types_controller.rb'
 require_relative './product_controller.rb'
+require_relative './order_controller.rb'
 
 class MainMenuController 
 
@@ -64,6 +65,14 @@ class MainMenuController
             end
         when '5'
         when '6'
+            if @active_customer
+                OrderController.new.complete_current_customer_open_order(@active_customer)
+                message = "Order Successfully completed."
+                display_main_menu(message)
+            else 
+                message = "Must set an active customer."
+                display_main_menu(message)
+            end
         when '7'
         when '8'
         when '9'

--- a/app/controllers/order_controller.rb
+++ b/app/controllers/order_controller.rb
@@ -1,10 +1,82 @@
 require './app/models/order_model.rb'
+require './app/models/product_model.rb'
+require './app/models/payment_types_model.rb'
 
 class OrderController
+
+	def initiallize
+
+	end
+
 	def addproduct(product)
 
 	end
+
 	def showproducts
 
 	end
+
+	def complete_current_customer_open_order(customerId)
+		open_order = OrderModel.new.get_current_customer_open_orders(customerId)
+        if open_order == []
+            puts "Please add some products to your order first. Press any key to return to main menu."
+            STDIN.gets.chomp
+		else
+			all_products_on_order = OrderModel.new.get_all_products_from_order(open_order[0][0])
+			product_info = Array.new
+			all_products_on_order.each_with_index do |p, i|	
+				product_info << Product.new.get_product_price_info(p[0])
+				product_info[i][0][:number_on_order] = all_products_on_order[i][1]
+			end
+			sum = get_total_price_of_order(product_info.flatten)
+			puts "Your order total is $#{sum}. Ready to purchase?"
+			puts "(y/n)"
+			if is_customer_ready_to_purchase?
+				payment_types_current_customer = PaymentTypeModel.new.get_current_customer_payment_types(customerId)
+				show_current_customer_payment_options(payment_types_current_customer)
+				option = STDIN.gets.chomp.to_i
+				payment_type_id = get_payment_type_id(option, payment_types_current_customer)
+				OrderModel.new.add_payment_type_to_open_order(open_order[0][0], payment_type_id)
+				OrderModel.new.set_order_status_completed_to_true(open_order[0][0])
+			else 
+				return
+			end
+			
+        end
+	end
+
+	def get_payment_type_id(option, payment_types)
+		payment_types[option-1][0]
+	end
+
+	def is_customer_ready_to_purchase?
+		option = STDIN.gets.chomp.downcase
+		case option
+		when 'y'
+			true
+		when 'n'
+			false
+		else
+			puts "Input not recognized. Please try again."
+			is_customer_ready_to_purchase?
+		end
+	end
+
+	def show_current_customer_payment_options(payment_types)
+
+		payment_types.each_with_index do |p, i|
+			puts "#{i+1}. #{p[2]}"
+		end
+
+	end
+
+	def get_total_price_of_order(products)
+		sum = 0
+		products.each do |p|
+			sum += p[2] * p[:number_on_order]
+		end
+		sum
+	end
+
+
 end

--- a/app/controllers/payment_types_controller.rb
+++ b/app/controllers/payment_types_controller.rb
@@ -111,5 +111,4 @@ class PaymentTypeController
         @payment_type_info[:customer_id] = customerId
     end
 
-
 end

--- a/app/models/order_model.rb
+++ b/app/models/order_model.rb
@@ -1,5 +1,34 @@
 require 'sqlite3'
 class OrderModel
+
+	def initialize
+		@db = SQLite3::Database.open('./db/sprint2.sqlite')
+		@db.results_as_hash = true
+	end
+
 	def showproducts
+
+	end
+
+	def get_current_customer_open_orders(customerId)
+		order = @db.execute("select o.* from Orders o where o.CustomerId = '#{customerId}' and o.Completed = '0'")
+		@db.close
+		return order
+	end
+
+	def get_all_products_from_order(orderId)
+		products_on_order = @db.execute("select op.ProductId, count(*) 'NumberProducts' from OrdersProducts op where op.OrderId = #{orderId} group by op.ProductId")
+		@db.close
+		return products_on_order
+	end
+
+	def add_payment_type_to_open_order(order_id, payment_type_id)
+		@db.execute("update Orders set PaymentTypeId = #{payment_type_id} where OrderId = #{order_id}")
+		@db.close
+	end
+
+	def set_order_status_completed_to_true(order_id)
+		@db.execute("update Orders set Completed = 1 where OrderId = #{order_id}")
+		@db.close
 	end
 end

--- a/app/models/payment_types_model.rb
+++ b/app/models/payment_types_model.rb
@@ -7,6 +7,7 @@ class PaymentTypeModel
 
     def initialize
         @db = SQLite3::Database.open('./db/sprint2.sqlite')
+        @db.results_as_hash = true
     end
 
     ##
@@ -23,6 +24,12 @@ class PaymentTypeModel
         ct = "#{d.month}/#{d.day}/#{d.year}"
         @db.execute("insert into PaymentTypes (CustomerId, Card_Name, Card_Number, created_at, updated_at) values (#{payment_type_info[:customer_id]}, '#{payment_type_info[:name]}', '#{payment_type_info[:account_number]}', '#{ct}', '#{ct}')")
         @db.close
+    end
+
+    def get_current_customer_payment_types(current_id)
+        payment_types = @db.execute("select pt.* from PaymentTypes pt where CustomerId = #{current_id}")
+        @db.close
+        payment_types
     end
 
 end

--- a/app/models/product_model.rb
+++ b/app/models/product_model.rb
@@ -85,7 +85,6 @@ class Product
       @db.close
     end
   end
-<<<<<<< HEAD
 
   def get_product_price_info(product_id)
     begin 
@@ -99,9 +98,6 @@ class Product
       
     end
   end
-end
-=======
->>>>>>> master
 
   ##
   ## @brief      gets a single product for specific customer

--- a/app/models/product_model.rb
+++ b/app/models/product_model.rb
@@ -25,8 +25,6 @@ class Product
     hash_from_controller[:created_at] = date
     hash_from_controller[:updated_at] = date
     begin
-      p @db
-      p hash_from_controller
       statement = "INSERT INTO Products(OwnerId, Title, Description, Price, Quantity, created_at, updated_at) VALUES( '#{hash_from_controller[:customer_id]}',
                   '#{hash_from_controller[:title]}', '#{hash_from_controller[:description]}',
                   '#{hash_from_controller[:price]}', '#{hash_from_controller[:quantity]}',
@@ -40,6 +38,19 @@ class Product
       @db.rollback
     ensure
       @db.close
+    end
+  end
+
+  def get_product_price_info(product_id)
+    begin 
+      return @db.execute("select p.ProductId, p.Title, p.Price from Products p where p.ProductId = #{product_id}")
+    rescue SQLite3::Exception => e
+      @db.rollback
+    else
+      
+    ensure
+      @db.close
+      
     end
   end
 end

--- a/db/create_tables.rb
+++ b/db/create_tables.rb
@@ -38,7 +38,7 @@ begin
     db.execute("CREATE TABLE `Orders` (
     `OrderId` INTEGER NOT NULL PRIMARY KEY autoincrement,
     `CustomerId` integer not null,
-    `PaymentTypeId` integer not null,
+    `PaymentTypeId` integer,
     `Completed` BOOLEAN not null,
     `created_at`    datetime NOT NULL,
     `updated_at`    datetime NOT NULL,

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -7,9 +7,7 @@ describe OrderController do
 	it "has a function to add a product to orders" do
 		expect(@order).to respond_to(:addproduct).with(1).arguments
 	end
-	# it "can add product to orders" do
-	# 	@order.addproduct(1)
-	# end
+
 	it "can show a list of products" do
 		expect(@order).to respond_to(:showproducts)
 	end
@@ -17,14 +15,6 @@ describe OrderController do
 	context "@ordermodel.get_current_customer_open_orders(id)" do
 		it "takes a single argument" do
 			expect(@ordermodel).to respond_to(:get_current_customer_open_orders).with(1).arguments
-		end
-
-		it "returns the correct order" do
-			# @customer = CustomerModel.new
-			# customer_hash = {:customer_name => 'Ron Swanson', :address => '111 Main St.', :city => 'Nashville', :state => 'TN', :zip => '33333', :phone => '6155555555', :created_at => '11/03/2017', :updated_at => '11/03/2017'}
-			# customer_id = @customer.add_customer(customer_hash)
-			customer_id = 1
-			expect(@ordermodel.get_current_customer_open_orders(customer_id)[0]).to include("CustomerId" => customer_id)
 		end
 
 		it "raises an argument error with 0 arguments given" do
@@ -36,36 +26,25 @@ describe OrderController do
 		end
 	end
 
-	context "@order.get_all_products_from_order(customerId, orderId)" do
+	context "@ordermodel.get_all_products_from_order(customerId, orderId)" do
 		it "takes a single argument" do
-			expect(@order).to respond_to(:get_all_products_from_order).with(2).arguments
+			expect(@ordermodel).to respond_to(:get_all_products_from_order).with(1).arguments
 		end
 
 		it "raises an argument error with 0 arguments given" do
-			expect{@order.get_all_products_from_order}.to raise_error(ArgumentError)
+			expect{@ordermodel.get_all_products_from_order}.to raise_error(ArgumentError)
 		end
 
 		it "raises an argument error with one argument given" do
-			expect{@order.get_all_products_from_order("arg1")}.to raise_error(ArgumentError)
+			expect{@ordermodel.get_all_products_from_order("arg1", "arg2")}.to raise_error(ArgumentError)
 		end
 
-		it "raises an argument error with more than two argument given" do
-			expect{@order.get_all_products_from_order("arg1", "arg2", "arg3")}.to raise_error(ArgumentError)
-		end
 	end
 
 	context "@ordermodel.get_all_products_from_order(id)" do
 		it "takes a single argument" do
 			expect(@ordermodel).to respond_to(:get_all_products_from_order).with(1).arguments
 		end
-
-		# it "returns the correct order" do
-		# 	# @customer = CustomerModel.new
-		# 	# customer_hash = {:customer_name => 'Ron Swanson', :address => '111 Main St.', :city => 'Nashville', :state => 'TN', :zip => '33333', :phone => '6155555555', :created_at => '11/03/2017', :updated_at => '11/03/2017'}
-		# 	# customer_id = @customer.add_customer(customer_hash)
-		# 	customer_id = 1
-		# 	expect(@ordermodel.get_all_products_from_order(customer_id)[0]).to include("CustomerId" => customer_id)
-		# end
 
 		it "raises an argument error with 0 arguments given" do
 			expect{@ordermodel.get_all_products_from_order}.to raise_error(ArgumentError)
@@ -75,6 +54,5 @@ describe OrderController do
 			expect{@ordermodel.get_all_products_from_order("arg1", "arg2")}.to raise_error(ArgumentError)
 		end
 	end
-
 
 end

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -55,4 +55,38 @@ describe OrderController do
 		end
 	end
 
+	context "@ordermodel.add_payment_type_to_open_order" do
+		it "takes a single argument" do
+			expect(@ordermodel).to respond_to(:add_payment_type_to_open_order).with(2).arguments
+		end
+
+		it "raises an argument error with 0 arguments given" do
+			expect{@ordermodel.add_payment_type_to_open_order}.to raise_error(ArgumentError)
+		end
+
+		it "raises an argument error with one argument given" do
+			expect{@ordermodel.add_payment_type_to_open_order("arg1")}.to raise_error(ArgumentError)
+		end
+	end
+
+	context "@order.get_payment_type_id" do
+		it "takes two arguments" do
+			expect(@order).to respond_to(:get_payment_type_id).with(2).arguments
+		end
+
+		it "gets the correct payment type based on customer input" do
+			option = 1
+			payment_types = [{0 => 1}]
+			expect(@order.get_payment_type_id(option, payment_types)).to eq(payment_types[option - 1][0])
+		end
+	end
+
+	context "@order.get_total_price_of_order" do
+		it "returns correct sum" do
+			products = [{2 => 5, :number_on_order => 2}, {2 => 5, :number_on_order => 1}]
+			expect(@order.get_total_price_of_order(products)).to eq(15)
+		end
+	end
+
+
 end

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -13,4 +13,68 @@ describe OrderController do
 	it "can show a list of products" do
 		expect(@order).to respond_to(:showproducts)
 	end
+
+	context "@ordermodel.get_current_customer_open_orders(id)" do
+		it "takes a single argument" do
+			expect(@ordermodel).to respond_to(:get_current_customer_open_orders).with(1).arguments
+		end
+
+		it "returns the correct order" do
+			# @customer = CustomerModel.new
+			# customer_hash = {:customer_name => 'Ron Swanson', :address => '111 Main St.', :city => 'Nashville', :state => 'TN', :zip => '33333', :phone => '6155555555', :created_at => '11/03/2017', :updated_at => '11/03/2017'}
+			# customer_id = @customer.add_customer(customer_hash)
+			customer_id = 1
+			expect(@ordermodel.get_current_customer_open_orders(customer_id)[0]).to include("CustomerId" => customer_id)
+		end
+
+		it "raises an argument error with 0 arguments given" do
+			expect{@ordermodel.get_current_customer_open_orders}.to raise_error(ArgumentError)
+		end
+
+		it "raises an argument error with more than one argument given" do
+			expect{@ordermodel.get_current_customer_open_orders("arg1", "arg2")}.to raise_error(ArgumentError)
+		end
+	end
+
+	context "@order.get_all_products_from_order(customerId, orderId)" do
+		it "takes a single argument" do
+			expect(@order).to respond_to(:get_all_products_from_order).with(2).arguments
+		end
+
+		it "raises an argument error with 0 arguments given" do
+			expect{@order.get_all_products_from_order}.to raise_error(ArgumentError)
+		end
+
+		it "raises an argument error with one argument given" do
+			expect{@order.get_all_products_from_order("arg1")}.to raise_error(ArgumentError)
+		end
+
+		it "raises an argument error with more than two argument given" do
+			expect{@order.get_all_products_from_order("arg1", "arg2", "arg3")}.to raise_error(ArgumentError)
+		end
+	end
+
+	context "@ordermodel.get_all_products_from_order(id)" do
+		it "takes a single argument" do
+			expect(@ordermodel).to respond_to(:get_all_products_from_order).with(1).arguments
+		end
+
+		# it "returns the correct order" do
+		# 	# @customer = CustomerModel.new
+		# 	# customer_hash = {:customer_name => 'Ron Swanson', :address => '111 Main St.', :city => 'Nashville', :state => 'TN', :zip => '33333', :phone => '6155555555', :created_at => '11/03/2017', :updated_at => '11/03/2017'}
+		# 	# customer_id = @customer.add_customer(customer_hash)
+		# 	customer_id = 1
+		# 	expect(@ordermodel.get_all_products_from_order(customer_id)[0]).to include("CustomerId" => customer_id)
+		# end
+
+		it "raises an argument error with 0 arguments given" do
+			expect{@ordermodel.get_all_products_from_order}.to raise_error(ArgumentError)
+		end
+
+		it "raises an argument error with more than one argument given" do
+			expect{@ordermodel.get_all_products_from_order("arg1", "arg2")}.to raise_error(ArgumentError)
+		end
+	end
+
+
 end


### PR DESCRIPTION
## Status
**READY**

## Description
Ability to complete an order by adding a PaymentTypeId to an order and setting the completed field for the order from false to true.

## Todos
- [ ] Documentation

## Steps to Test or Reproduce

```
git fetch origin complete_open_order_ml
git checkout complete_open_order_ml
ruby app/main.rb
```

**NOTE: The db/create_tables.rb file will need to be changed. When creating the Orders table, the 'PaymentTypeId' WILL BE allowed to be null currently the rules state it cannot be null. So, when creating a new order for a customer the new order should have a PaymentTypeId of 'NULL' and a Completed of false**


1.  Set active customer

2. Create new order for customer (If functionality not finished then manually create an order directly in the database)

3. Add some products to the order

4. Choose the complete the order option and complete the order.

## Impacted Areas in Application
PaymentTypes, Orders, Products, Tests, DB

